### PR TITLE
fix: correctly display custom transaction modal errors

### DIFF
--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -23,6 +23,7 @@ Hier sind die Anwendungsfälle, die diese Software implementiert, niedergeschrie
 ## Eigene Buchung
 
 - [x] Eigene Buchung erstellen: Ein Benutzer klickt auf "Eigene Buchung", gibt eine Beschreibung und einen Betrag (innerhalb der konfigurierten Grenzen) ein und bestätigt. Eine Transaktion wird erstellt und das Guthaben entsprechend angepasst.
+- [x] Eigene Buchung Validierungsfehler: Ein Benutzer gibt ungültige Daten ein (leere Beschreibung, ungültiger Betrag, Betrag außerhalb der Grenzen). Das Modal bleibt offen und zeigt die Fehlermeldung inline an.
 - Eigene Buchung bei Ausgabelimit: Ein Benutzer mit erreichtem Ausgabelimit kann keine eigene Buchung erstellen — der Button ist deaktiviert.
 
 ## Transaktionshistorie

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -35,6 +35,57 @@ test.describe('Transactions & Profile', () => {
     ).toBeVisible({ timeout: 5000 });
   });
 
+  test('Eigene Buchung: Fehler bei leerer Beschreibung', async ({ page }) => {
+    await page.goto('/');
+
+    const trigger = page.locator('li', { hasText: 'Eigene Buchung' });
+    await trigger.click();
+
+    const modal = page.locator('#modal .modal-open');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await page.fill('#custom-tx-amount', '2.50');
+    await page.click('#custom-tx-confirm-btn');
+
+    // Modal stays open with inline error
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.alert-error')).toContainText('Beschreibung ist erforderlich');
+  });
+
+  test('Eigene Buchung: Fehler bei ungültigem Betrag', async ({ page }) => {
+    await page.goto('/');
+
+    const trigger = page.locator('li', { hasText: 'Eigene Buchung' });
+    await trigger.click();
+
+    const modal = page.locator('#modal .modal-open');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await page.fill('#custom-tx-description', 'Test');
+    await page.fill('#custom-tx-amount', '0');
+    await page.click('#custom-tx-confirm-btn');
+
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.alert-error')).toContainText('Ungültiger Betrag');
+  });
+
+  test('Eigene Buchung: Fehler bei Betrag über Maximum', async ({ page }) => {
+    await page.goto('/');
+
+    const trigger = page.locator('li', { hasText: 'Eigene Buchung' });
+    await trigger.click();
+
+    const modal = page.locator('#modal .modal-open');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    await page.fill('#custom-tx-description', 'Test');
+    await page.fill('#custom-tx-amount', '99.99');
+    await page.click('#custom-tx-confirm-btn');
+
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.alert-error')).toContainText('Maximalbetrag');
+  });
+
   test('Transaktion stornieren', async ({ page }) => {
     await page.goto('/transactions');
 

--- a/internal/handler/history.go
+++ b/internal/handler/history.go
@@ -100,8 +100,9 @@ func (h *Handler) TransactionHistory(w http.ResponseWriter, r *http.Request) err
 
 // CustomTransactionModalData is the view model for the custom transaction modal.
 type CustomTransactionModalData struct {
-	Settings  *model.Settings
-	CSRFToken string
+	Settings     *model.Settings
+	CSRFToken    string
+	ErrorMessage string
 }
 
 // CustomTransactionModal renders the custom transaction modal.
@@ -197,35 +198,50 @@ func (h *Handler) CreateCustomTransaction(w http.ResponseWriter, r *http.Request
 	user := auth.UserFromContext(ctx)
 	db := h.Store.DB()
 
+	// Fetch settings early — needed for both validation and error re-rendering.
+	settings, err := store.GetSettings(ctx, db)
+	if err != nil {
+		return fmt.Errorf("create custom transaction: get settings: %w", err)
+	}
+
+	// Re-render the modal with an inline error message.
+	renderError := func(msg string) error {
+		data := CustomTransactionModalData{
+			Settings:     settings,
+			CSRFToken:    middleware.CSRFTokenFromContext(ctx),
+			ErrorMessage: msg,
+		}
+		h.Renderer.Fragment(w, r, "custom-transaction-modal", data)
+		return nil
+	}
+
 	// Parse form data.
 	description := strings.TrimSpace(r.FormValue("description"))
 
 	if description == "" {
-		return &ValidationError{Message: "Beschreibung ist erforderlich"}
+		return renderError("Beschreibung ist erforderlich")
 	}
 	if err := validateTextLen(description, 500, "Beschreibung"); err != nil {
+		var ve *ValidationError
+		if errors.As(err, &ve) {
+			return renderError(ve.Message)
+		}
 		return err
 	}
 
 	// Parse Euro amount string to cents (accepts both comma and period).
 	amountFloat, err := strconv.ParseFloat(normalizeDecimal(r.FormValue("amount")), 64)
 	if err != nil || amountFloat <= 0 {
-		return &ValidationError{Message: "Ungültiger Betrag"}
+		return renderError("Ungültiger Betrag")
 	}
 	amountCents := int64(math.Round(amountFloat * 100))
 
-	// Fetch settings for custom_tx_min/max.
-	settings, err := store.GetSettings(ctx, db)
-	if err != nil {
-		return fmt.Errorf("create custom transaction: get settings: %w", err)
-	}
-
 	// Validate amount within allowed range.
 	if amountCents < settings.CustomTxMin {
-		return &ValidationError{Message: fmt.Sprintf("Mindestbetrag: %s", formatEuroCents(settings.CustomTxMin))}
+		return renderError(fmt.Sprintf("Mindestbetrag: %s", formatEuroCents(settings.CustomTxMin)))
 	}
 	if amountCents > settings.CustomTxMax {
-		return &ValidationError{Message: fmt.Sprintf("Maximalbetrag: %s", formatEuroCents(settings.CustomTxMax))}
+		return renderError(fmt.Sprintf("Maximalbetrag: %s", formatEuroCents(settings.CustomTxMax)))
 	}
 
 	// Create transaction (amount is negative = debit).

--- a/templates/partials/custom_transaction_modal.html
+++ b/templates/partials/custom_transaction_modal.html
@@ -3,9 +3,11 @@
     <div class="modal-box">
         <h3 class="font-bold text-lg">Eigene Buchung</h3>
 
-        <div id="custom-tx-error" class="alert alert-error mt-3 hidden">
-            <span id="custom-tx-error-msg"></span>
+        {{if .ErrorMessage}}
+        <div class="alert alert-error mt-3">
+            <span>{{.ErrorMessage}}</span>
         </div>
+        {{end}}
 
         <div class="py-4">
             <fieldset class="fieldset mb-4">
@@ -37,24 +39,7 @@
 
 <script>
 (function() {
-    // Show the modal container.
     document.getElementById('modal').style.display = '';
-
-    // Handle error responses inline in the modal.
-    var btn = document.getElementById('custom-tx-confirm-btn');
-    btn.addEventListener('htmx:beforeSwap', function(evt) {
-        if (evt.detail.xhr.status >= 400) {
-            evt.detail.shouldSwap = false;
-            var errDiv = document.getElementById('custom-tx-error');
-            var errMsg = document.getElementById('custom-tx-error-msg');
-            // Extract text from the HTML response.
-            var tmp = document.createElement('div');
-            tmp.innerHTML = evt.detail.xhr.responseText;
-            var span = tmp.querySelector('span');
-            errMsg.textContent = span ? span.textContent : 'Ein Fehler ist aufgetreten';
-            errDiv.classList.remove('hidden');
-        }
-    });
 })();
 </script>
 {{end}}


### PR DESCRIPTION
- add an alert bar above the form
- replace modal with error modal on erroneous submit